### PR TITLE
feat: add lazy monaco viewer

### DIFF
--- a/src/components/MonacoViewer.jsx
+++ b/src/components/MonacoViewer.jsx
@@ -15,10 +15,10 @@ export default function MonacoViewer({ value = "", language = "plaintext", theme
     requestAnimationFrame(() => editor.layout());
   };
 
-  // Keep editor sized to container via ResizeObserver
+  // Keep editor sized to container via ResizeObserver when available
   useEffect(() => {
     const el = containerRef.current;
-    if (!el) return;
+    if (!el || typeof ResizeObserver === "undefined") return;
     const ro = new ResizeObserver(() => {
       if (editorRef.current) editorRef.current.layout();
     });

--- a/src/components/MonacoViewer.jsx
+++ b/src/components/MonacoViewer.jsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useRef, Suspense } from "react";
+// Lazy-load Monaco editor to keep initial bundle size small
+const Editor = React.lazy(() => import("@monaco-editor/react"));
+
+import { defineCustomMonacoThemes, getEnhancedTheme } from "../utils/monacoThemes";
+
+export default function MonacoViewer({ value = "", language = "plaintext", theme = "vs" }) {
+  const containerRef = useRef(null);
+  const editorRef = useRef(null);
+
+  const handleMount = (editor, monaco) => {
+    editorRef.current = editor;
+    defineCustomMonacoThemes(monaco);
+    // First layout after mount
+    requestAnimationFrame(() => editor.layout());
+  };
+
+  // Keep editor sized to container via ResizeObserver
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver(() => {
+      if (editorRef.current) editorRef.current.layout();
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  // Also relayout on window resize
+  useEffect(() => {
+    const fn = () => editorRef.current && editorRef.current.layout();
+    window.addEventListener("resize", fn);
+    return () => window.removeEventListener("resize", fn);
+  }, []);
+
+  return (
+    <div
+      ref={containerRef}
+      className="h-full w-full min-w-0"
+      style={{ position: "relative", overflow: "hidden" }}
+    >
+      <Suspense fallback={<pre className="p-2 overflow-auto">{value}</pre>}>
+        <Editor
+          value={value}
+          language={language}
+          onMount={handleMount}
+          theme={getEnhancedTheme(theme)}
+          width="100%"
+          height="100%"
+          options={{
+            readOnly: true,
+            automaticLayout: false,
+            minimap: { enabled: false },
+            scrollBeyondLastLine: false,
+            wordWrap: "on",
+            renderLineHighlight: "none",
+            fontSize: 12,
+            lineNumbers: "on",
+            folding: true,
+            foldingStrategy: "indentation",
+            showFoldingControls: "mouseover",
+            lineDecorationsWidth: 10,
+            lineNumbersMinChars: 3,
+            renderWhitespace: "selection",
+            selectionHighlight: true,
+            occurrencesHighlight: true,
+            insertSpaces: true,
+            tabSize: 2,
+            detectIndentation: true,
+            formatOnPaste: true,
+            formatOnType: false,
+            contextmenu: true,
+            dragAndDrop: true,
+          }}
+        />
+      </Suspense>
+    </div>
+  );
+}

--- a/src/components/StreamedResultViewer.jsx
+++ b/src/components/StreamedResultViewer.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import MonacoViewer from "./MonacoViewer";
 
-// Map MIME type to Monaco language
+// Map MIME type to a Monaco language id
 function getLanguageFromMimeType(mimeType) {
   if (!mimeType) return "plaintext";
   const type = mimeType.toLowerCase();
@@ -12,11 +12,15 @@ function getLanguageFromMimeType(mimeType) {
   return "plaintext";
 }
 
-export default function StreamedResultViewer({ content = "", mimeType }) {
-  const language = getLanguageFromMimeType(mimeType);
+// Accept either a full part object or raw content/mimeType props
+export default function StreamedResultViewer({ part, content = "", mimeType }) {
+  const actualContent = part?.content ?? content ?? "";
+  const type = part?.mimeType || part?.contentType || mimeType;
+  const language = getLanguageFromMimeType(type);
+
   return (
     <div className="h-full w-full">
-      <MonacoViewer value={content} language={language} />
+      <MonacoViewer value={actualContent} language={language} />
     </div>
   );
 }

--- a/src/components/StreamedResultViewer.jsx
+++ b/src/components/StreamedResultViewer.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import MonacoViewer from "./MonacoViewer";
 
 // Map MIME type to a Monaco language id
@@ -12,14 +12,60 @@ function getLanguageFromMimeType(mimeType) {
   return "plaintext";
 }
 
-// Accept either a full part object or raw content/mimeType props
-export default function StreamedResultViewer({ part, content = "", mimeType }) {
+/**
+ * Display streamed evaluation results showing per-part byte sizes and
+ * cumulative download progress. The component listens for the
+ * `eval-stream-progress` IPC event exposed through the preload script.
+ *
+ * Additionally, when a part's content is provided via `part` or explicit
+ * `content`/`mimeType` props, it renders the payload using the Monaco viewer
+ * with syntax highlighting based on the MIME type.
+ *
+ * @param {object} props
+ * @param {object} [props.index] JSON index describing stream parts
+ * @param {object} [props.part] Stream part containing `content` and `mimeType`
+ * @param {string} [props.content] Raw content to display
+ * @param {string} [props.mimeType] MIME type of the content
+ */
+export default function StreamedResultViewer({
+  index,
+  part,
+  content = "",
+  mimeType,
+}) {
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    if (window.electronAPI?.onEvalStreamProgress) {
+      const remove = window.electronAPI.onEvalStreamProgress((total) => {
+        setProgress(total);
+      });
+      return () => remove && remove();
+    }
+  }, []);
+
+  const parts = index?.parts || [];
+  const totalBytes = parts.reduce((sum, p) => sum + (p.bytes || 0), 0);
+
   const actualContent = part?.content ?? content ?? "";
   const type = part?.mimeType || part?.contentType || mimeType;
   const language = getLanguageFromMimeType(type);
 
   return (
-    <div className="h-full w-full">
+    <div className="streamed-result-viewer h-full w-full">
+      <div className="progress mb-2">
+        <span data-testid="byte-progress">{progress} bytes</span>
+      </div>
+      <ul>
+        {parts.map((p, i) => (
+          <li key={i} data-testid={`part-${i}-bytes`}>
+            Part {i + 1}: {p.bytes} bytes
+          </li>
+        ))}
+      </ul>
+      <div className="mt-2 font-bold" data-testid="total-bytes">
+        Total: {totalBytes} bytes
+      </div>
       <MonacoViewer value={actualContent} language={language} />
     </div>
   );

--- a/src/components/StreamedResultViewer.jsx
+++ b/src/components/StreamedResultViewer.jsx
@@ -1,0 +1,22 @@
+import React from "react";
+import MonacoViewer from "./MonacoViewer";
+
+// Map MIME type to Monaco language
+function getLanguageFromMimeType(mimeType) {
+  if (!mimeType) return "plaintext";
+  const type = mimeType.toLowerCase();
+  if (type.includes("json")) return "json";
+  if (type.includes("xml")) return "xml";
+  if (type.includes("html")) return "html";
+  if (type.includes("javascript") || type.includes("js")) return "javascript";
+  return "plaintext";
+}
+
+export default function StreamedResultViewer({ content = "", mimeType }) {
+  const language = getLanguageFromMimeType(mimeType);
+  return (
+    <div className="h-full w-full">
+      <MonacoViewer value={content} language={language} />
+    </div>
+  );
+}

--- a/src/test/setup.jsx
+++ b/src/test/setup.jsx
@@ -2,7 +2,19 @@
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 
-// Mock Monaco Editor to prevent issues in jsdom  
+// Polyfill ResizeObserver for the jsdom environment
+class ResizeObserver {
+  constructor(callback) {
+    // store callback but never invoke in tests
+    this.callback = callback;
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+global.ResizeObserver = ResizeObserver;
+
+// Mock Monaco Editor to prevent issues in jsdom
 vi.mock('@monaco-editor/react', () => ({
   default: vi.fn(({ value, language, height }) => {
     return vi.fn().mockReturnValue(null)();

--- a/src/test/setup.jsx
+++ b/src/test/setup.jsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 
 // Polyfill ResizeObserver for the jsdom environment if missing
-if (typeof global.ResizeObserver === "undefined") {
+if (typeof global.ResizeObserver === 'undefined') {
   class ResizeObserver {
     constructor(callback) {
       // store callback but never invoke in tests
@@ -14,6 +14,10 @@ if (typeof global.ResizeObserver === "undefined") {
     disconnect() {}
   }
   global.ResizeObserver = ResizeObserver;
+  // ensure browser-like global also has it
+  if (typeof window !== 'undefined') {
+    window.ResizeObserver = ResizeObserver;
+  }
 }
 
 // Mock Monaco Editor to prevent issues in jsdom

--- a/src/test/setup.jsx
+++ b/src/test/setup.jsx
@@ -2,17 +2,19 @@
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 
-// Polyfill ResizeObserver for the jsdom environment
-class ResizeObserver {
-  constructor(callback) {
-    // store callback but never invoke in tests
-    this.callback = callback;
+// Polyfill ResizeObserver for the jsdom environment if missing
+if (typeof global.ResizeObserver === "undefined") {
+  class ResizeObserver {
+    constructor(callback) {
+      // store callback but never invoke in tests
+      this.callback = callback;
+    }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
   }
-  observe() {}
-  unobserve() {}
-  disconnect() {}
+  global.ResizeObserver = ResizeObserver;
 }
-global.ResizeObserver = ResizeObserver;
 
 // Mock Monaco Editor to prevent issues in jsdom
 vi.mock('@monaco-editor/react', () => ({


### PR DESCRIPTION
## Summary
- add reusable MonacoViewer component that lazy-loads monaco editor assets and renders read-only content
- use new viewer in StreamedResultViewer to highlight streamed result content based on MIME type

## Testing
- `npm test` *(fails: ResizeObserver is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68be125ce2ac83278cee9c374443f929