### PR TITLE
Add streamed evaluation progress and result viewer

### DIFF
--- a/electron/eval-stream.js
+++ b/electron/eval-stream.js
@@ -1,0 +1,66 @@
+const { ipcMain } = require('electron');
+const http = require('http');
+const https = require('https');
+const { URL } = require('url');
+
+/**
+ * Fetch a URL and stream the response, emitting byte progress via IPC.
+ * @param {Object} options
+ * @param {string} options.url The URL to request
+ * @param {string} [options.method] HTTP method
+ * @param {Object} [options.headers] Request headers
+ * @param {string|Buffer} [options.body] Optional request body
+ * @returns {Promise<{status:number, headers:Object, body:string}>}
+ */
+function evalStream(options = {}) {
+  return new Promise((resolve, reject) => {
+    try {
+      const url = new URL(options.url);
+      const isHttps = url.protocol === 'https:';
+      const httpModule = isHttps ? https : http;
+
+      const requestOptions = {
+        hostname: url.hostname,
+        port: url.port || (isHttps ? 443 : 80),
+        path: url.pathname + url.search,
+        method: options.method || 'GET',
+        headers: options.headers || {},
+        rejectUnauthorized: false,
+      };
+
+      const req = httpModule.request(requestOptions, (res) => {
+        const chunks = [];
+        let total = 0;
+
+        res.on('data', (chunk) => {
+          chunks.push(chunk);
+          total += chunk.length;
+          // Emit progress so renderer can update UI
+          ipcMain.emit('eval-stream-progress', total);
+        });
+
+        res.on('end', () => {
+          resolve({
+            status: res.statusCode,
+            headers: res.headers,
+            body: Buffer.concat(chunks).toString(),
+          });
+        });
+
+        res.on('error', reject);
+      });
+
+      req.on('error', reject);
+
+      if (options.body) {
+        req.write(options.body);
+      }
+
+      req.end();
+    } catch (err) {
+      reject(err);
+    }
+  });
+}
+
+module.exports = evalStream;

--- a/electron/main.js
+++ b/electron/main.js
@@ -6,6 +6,7 @@ const { URL } = require('url');
 const crypto = require('crypto');
 const { spawn } = require('child_process');
 const QueryRepository = require('./database');
+const evalStream = require('./eval-stream');
 
 let mainWindow;
 let queryRepository;
@@ -481,4 +482,14 @@ ipcMain.handle('run-command', async (event, options) => {
       reject(new Error('Command timeout'));
     }, 300000); // 5 minutes timeout
   });
+});
+
+ipcMain.handle('eval-stream', async (event, options) => {
+  return evalStream(options);
+});
+
+ipcMain.on('eval-stream-progress', (event, total) => {
+  if (mainWindow) {
+    mainWindow.webContents.send('eval-stream-progress', total);
+  }
 });

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -4,6 +4,12 @@ const { contextBridge, ipcRenderer } = require('electron');
 // the ipcRenderer without exposing the entire object
 contextBridge.exposeInMainWorld('electronAPI', {
   httpRequest: (options) => ipcRenderer.invoke('http-request', options),
+  evalStream: (options) => ipcRenderer.invoke('eval-stream', options),
+  onEvalStreamProgress: (callback) => {
+    const handler = (_event, total) => callback(total);
+    ipcRenderer.on('eval-stream-progress', handler);
+    return () => ipcRenderer.removeListener('eval-stream-progress', handler);
+  },
   
   // Command execution
   runCommand: (options) => ipcRenderer.invoke('run-command', options),

--- a/src/components/StreamedResultViewer.jsx
+++ b/src/components/StreamedResultViewer.jsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+
+/**
+ * Display streamed evaluation results showing per-part byte sizes and
+ * cumulative download progress. The component listens for the
+ * `eval-stream-progress` IPC event exposed through the preload script.
+ *
+ * @param {object} props
+ * @param {object} props.index JSON index describing stream parts
+ */
+export default function StreamedResultViewer({ index }) {
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    if (window.electronAPI?.onEvalStreamProgress) {
+      const remove = window.electronAPI.onEvalStreamProgress((total) => {
+        setProgress(total);
+      });
+      return () => remove && remove();
+    }
+  }, []);
+
+  const parts = index?.parts || [];
+  const totalBytes = parts.reduce((sum, p) => sum + (p.bytes || 0), 0);
+
+  return (
+    <div className="streamed-result-viewer">
+      <div className="progress mb-2">
+        <span data-testid="byte-progress">{progress} bytes</span>
+      </div>
+      <ul>
+        {parts.map((part, i) => (
+          <li key={i} data-testid={`part-${i}-bytes`}>
+            Part {i + 1}: {part.bytes} bytes
+          </li>
+        ))}
+      </ul>
+      <div className="mt-2 font-bold" data-testid="total-bytes">
+        Total: {totalBytes} bytes
+      </div>
+    </div>
+  );
+}

--- a/src/test/setup.jsx
+++ b/src/test/setup.jsx
@@ -2,6 +2,15 @@
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 
+// Provide a lightweight ResizeObserver mock for components relying on it
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+global.ResizeObserver = ResizeObserver;
+window.ResizeObserver = ResizeObserver;
+
 // Mock Monaco Editor to prevent issues in jsdom  
 vi.mock('@monaco-editor/react', () => ({
   default: vi.fn(({ value, language, height }) => {


### PR DESCRIPTION
## Summary
- emit running byte totals from eval-stream over IPC and forward to renderer
- expose eval-stream API and progress listener in preload
- add StreamedResultViewer to display per-part and cumulative byte counts
- polyfill ResizeObserver for tests

## Testing
- `npm test` *(fails: Console tab class expectation and executeQuery log not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be21d09bf08327b1b3187b61401bff