### PR TITLE
feat: add eval stream progress

### DIFF
--- a/electron/eval-stream.js
+++ b/electron/eval-stream.js
@@ -1,0 +1,53 @@
+const { ipcMain } = require('electron');
+const http = require('http');
+const https = require('https');
+const { URL } = require('url');
+
+/**
+ * Perform an HTTP(S) request to the MarkLogic /v1/eval endpoint and
+ * emit progress events indicating the total number of bytes received.
+ *
+ * @param {Object} options - Request options (method, headers, body, url)
+ * @returns {Promise<Buffer>} Resolves with the full response body
+ */
+function evalStream(options) {
+  return new Promise((resolve, reject) => {
+    try {
+      const url = new URL(options.url);
+      const isHttps = url.protocol === 'https:';
+      const httpModule = isHttps ? https : http;
+
+      const req = httpModule.request({
+        method: options.method || 'POST',
+        hostname: url.hostname,
+        port: url.port || (isHttps ? 443 : 80),
+        path: url.pathname + url.search,
+        headers: options.headers || {},
+      }, (res) => {
+        const chunks = [];
+        let total = 0;
+
+        res.on('data', (chunk) => {
+          chunks.push(chunk);
+          total += chunk.length;
+          ipcMain.emit('eval-stream-progress', total);
+        });
+
+        res.on('end', () => {
+          resolve(Buffer.concat(chunks));
+        });
+      });
+
+      req.on('error', reject);
+
+      if (options.body) {
+        req.write(options.body);
+      }
+      req.end();
+    } catch (err) {
+      reject(err);
+    }
+  });
+}
+
+module.exports = evalStream;

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -4,9 +4,15 @@ const { contextBridge, ipcRenderer } = require('electron');
 // the ipcRenderer without exposing the entire object
 contextBridge.exposeInMainWorld('electronAPI', {
   httpRequest: (options) => ipcRenderer.invoke('http-request', options),
-  
+
   // Command execution
   runCommand: (options) => ipcRenderer.invoke('run-command', options),
+
+  // Streamed evaluation progress
+  onEvalStreamProgress: (callback) =>
+    ipcRenderer.on('eval-stream-progress', (event, total) => callback(total)),
+  removeEvalStreamProgressListener: (callback) =>
+    ipcRenderer.removeListener('eval-stream-progress', callback),
   
   // Database operations
   database: {

--- a/src/components/StreamedResultViewer.jsx
+++ b/src/components/StreamedResultViewer.jsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useState } from "react";
+
+/**
+ * Displays progress information for streamed eval results.
+ * Fetches an index.json describing the parts and shows the byte
+ * count for each part along with a running cumulative total.
+ */
+export default function StreamedResultViewer({ indexUrl }) {
+  const [parts, setParts] = useState([]);
+  const [totalBytes, setTotalBytes] = useState(0);
+  const [received, setReceived] = useState(0);
+
+  // Load index.json describing the streamed parts
+  useEffect(() => {
+    if (!indexUrl) return;
+    fetch(indexUrl)
+      .then((res) => res.json())
+      .then((data) => {
+        const arr = Array.isArray(data) ? data : data.parts || [];
+        setParts(arr);
+        const total = arr.reduce((sum, p) => sum + (p.bytes || 0), 0);
+        setTotalBytes(total);
+      })
+      .catch(() => {
+        setParts([]);
+        setTotalBytes(0);
+      });
+  }, [indexUrl]);
+
+  // Listen for streamed progress events from Electron
+  useEffect(() => {
+    const handler = (total) => setReceived(total);
+    if (window.electronAPI?.onEvalStreamProgress) {
+      window.electronAPI.onEvalStreamProgress(handler);
+      return () => {
+        window.electronAPI.removeEvalStreamProgressListener?.(handler);
+      };
+    }
+  }, []);
+
+  const cumulative = parts.reduce((acc, part) => {
+    const next = acc.total + (part.bytes || 0);
+    acc.list.push({ ...part, cumulative: next });
+    acc.total = next;
+    return acc;
+  }, { list: [], total: 0 }).list;
+
+  return (
+    <div className="space-y-2">
+      <div className="text-sm">
+        Received {received} / {totalBytes} bytes
+      </div>
+      <progress className="progress w-full" value={received} max={totalBytes}></progress>
+      <ul className="text-sm space-y-1">
+        {cumulative.map((p, idx) => (
+          <li key={idx}>
+            {p.name || `Part ${idx + 1}`}: {p.bytes} bytes (total {p.cumulative})
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- stream eval responses and emit total byte progress from main process
- expose eval stream progress events to renderer and display bytes received while loading
- add StreamedResultViewer component that lists per-part byte sizes and cumulative totals

## Testing
- `npm test` *(fails: ResizeObserver is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68be179aba888327abda08930e0b6b1f