### PR TITLE
Remove parsed/raw view modes, keep table view only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ test-results/
 
 # Claude Code local settings
 .claude/settings.local.json
+
+# DevContainer with credentials
+.devcontainer/


### PR DESCRIPTION
## Summary
- Removed parsed text and raw output view modes
- Table view is now the only/default display mode
- Removed view mode dropdown selector
- Simplified results rendering

## Changes
- Removed `viewMode` and `rawResults` state variables
- Removed view mode dropdown from Results header
- Removed view mode change effect (lines 435-448)
- Removed all `viewMode === 'table'` conditionals
- Added fallback Monaco editor for non-tabular results
- Cleaned up keyboard shortcuts to remove viewMode check
- Added `.devcontainer/` to `.gitignore`

## Impact
- **Simpler UX**: Single results display (no confusing mode selector)
- **Fully functional**: Table view works with streaming and static modes
- **Backwards compatible**: Non-tabular results still display in Monaco editor fallback
- **Navigation preserved**: Ctrl+Up/Down arrows, pagination all work

**Net change**: -51 lines, +19 lines